### PR TITLE
Return Datastore from QutipBackend.run

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ from oqd_core.interface.analog.operator import *
 from oqd_core.interface.analog.operation import *
 from oqd_core.backend.metric import *
 from oqd_core.backend.task import Task, TaskArgsAnalog
-from oqd_analog_emulator.datastore import metric_labels_from_dataset
 from oqd_analog_emulator.qutip_backend import QutipBackend
 
 X = PauliX()
@@ -83,7 +82,7 @@ datastore.model_dump_hdf5("rabi_run.h5")
 
 sim = datastore.groups["emulation"]
 times = sim.times.data
-z_idx = metric_labels_from_dataset(sim.metrics).index("Z")
+z_idx = sim.metrics.attrs["metric_labels"].split(",").index("Z")
 z = sim.metrics.data[:, z_idx]
 
 plt.plot(times, z, label=f"$\\langle Z \\rangle$")

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ from oqd_core.interface.analog.operator import *
 from oqd_core.interface.analog.operation import *
 from oqd_core.backend.metric import *
 from oqd_core.backend.task import Task, TaskArgsAnalog
+from oqd_analog_emulator.datastore import metric_labels_from_dataset
 from oqd_analog_emulator.qutip_backend import QutipBackend
 
 X = PauliX()
@@ -77,9 +78,15 @@ args = TaskArgsAnalog(
 task = Task(program=circuit, args=args)
 
 backend = QutipBackend()
-results = backend.run(task=task)
+datastore = backend.run(task=task)
+datastore.model_dump_hdf5("rabi_run.h5")
 
-plt.plot(results.times, results.metrics["Z"], label=f"$\\langle Z \\rangle$")
+sim = datastore.groups["emulation"]
+times = sim.times.data
+z_idx = metric_labels_from_dataset(sim.metrics).index("Z")
+z = sim.metrics.data[:, z_idx]
+
+plt.plot(times, z, label=f"$\\langle Z \\rangle$")
 ```
 
 ### Where in the stack

--- a/docs/explanation/qutip-simulation.md
+++ b/docs/explanation/qutip-simulation.md
@@ -17,5 +17,5 @@ After compilation, the time dynamical evolution is emulated using the Qutip impl
     User_Input --> OpenQSIM: The user inputs are put in the OpenQSIM AST's Task object
     OpenQSIM --> OpenQSIM(canonicalized): RewriteRule (Canonicalization of Operators)
     OpenQSIM(canonicalized) --> QutipExperiment: compile the program of Task to QutipExperiment. And also convert the analog
-    QutipExperiment --> TaskResultAnalog: Run the experiment using the QutipExperimentVM Virtual Machine.
+    QutipExperiment --> Datastore: Run the experiment using the QutipExperimentVM Virtual Machine.
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
   "setuptools",
   "oqd-compiler-infrastructure@git+https://github.com/openquantumdesign/oqd-compiler-infrastructure",
   "oqd-core@git+https://github.com/openquantumdesign/oqd-core",
+  "oqd-dataschema@git+https://github.com/OpenQuantumDesign/oqd-dataschema",
 ]
 
 [project.optional-dependencies]

--- a/src/oqd_analog_emulator/conversion.py
+++ b/src/oqd_analog_emulator/conversion.py
@@ -114,6 +114,8 @@ class QutipExperimentVM(RewriteRule):
         self._n_shots = n_shots
         self._fock_cutoff = fock_cutoff
         self._dt = dt
+        self._state_trajectory: list[list] = []
+        self._measurements: np.ndarray | None = None
 
     def map_QutipExperiment(self, model):
         dims = model.n_qreg * [2] + model.n_qmode * [self._fock_cutoff]
@@ -122,9 +124,9 @@ class QutipExperimentVM(RewriteRule):
         self.current_state = qt.tensor([qt.basis(d, 0) for d in dims])
 
         self.results.times.append(0.0)
-        self.results.state = list(
-            self.current_state.full().squeeze(),
-        )
+        initial_state = list(self.current_state.full().squeeze())
+        self.results.state = initial_state
+        self._state_trajectory.append(initial_state)
         self.results.metrics.update(
             {
                 key: [self._qt_metrics[key](0.0, self.current_state)]
@@ -144,6 +146,7 @@ class QutipExperimentVM(RewriteRule):
             ]
             bases = list(itertools.product(*opts))
             shots = np.array([bases[ind] for ind in inds])
+            self._measurements = shots[:, : self.n_qreg].astype(np.int64)
             bitstrings = ["".join(map(str, shot)) for shot in shots]
             self.results.counts = {
                 bitstring: bitstrings.count(bitstring) for bitstring in bitstrings
@@ -177,6 +180,10 @@ class QutipExperimentVM(RewriteRule):
 
         for idx, key in enumerate(self.results.metrics.keys()):
             self.results.metrics[key].extend(result_qobj.expect[idx].tolist()[1:])
+
+        if result_qobj.states is not None:
+            for st in result_qobj.states[1:]:
+                self._state_trajectory.append(list(st.full().squeeze()))
 
         self.current_state = result_qobj.final_state
 

--- a/src/oqd_analog_emulator/conversion.py
+++ b/src/oqd_analog_emulator/conversion.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
 import itertools
 import time
+
+import numpy as np
 import qutip as qt
 
 from oqd_compiler_infrastructure import ConversionRule, RewriteRule, Chain
-from oqd_core.backend.task import TaskResultAnalog
 from oqd_core.compiler.math.passes import (
     evaluate_math_expr,
     simplify_math_expr,
@@ -43,6 +43,12 @@ __all__ = [
     "QutipBackendCompiler",
     "QutipExperimentVM",
 ]
+
+
+def _qobj_to_state_vector(state: qt.Qobj) -> np.ndarray:
+    """Extract a 1D complex128 state vector from a QuTiP Qobj."""
+    return np.asarray(state.full(), dtype=np.complex128).squeeze()
+
 
 ########################################################################################
 
@@ -95,27 +101,31 @@ class QutipMetricConversion(ConversionRule):
 
 class QutipExperimentVM(RewriteRule):
     """
-    This is a Virtual Machine which takes in a QutipExperiment object, simulates the experiment and then produces the results
+    Virtual machine that simulates a [`QutipExperiment`][oqd_analog_emulator.interface.QutipExperiment]
+    and collects run data as plain numpy-friendly attributes for datastore export.
 
-    Args:
-        model (QutipExperiment): This is the compiled  [`QutipExperiment`][oqd_analog_emulator.qutip_backend.QutipExperiment] object
-
-    Returns:
-        task (TaskResultAnalog):
-
-    Note:
-        n_qreg and n_qmode are given as compiler parameters
+    Attributes populated during execution:
+        times: simulation time points
+        metric_labels: ordered metric names
+        metrics: expectation time-series per metric
+        state_trajectory: state vectors at each time step
+        measurements: sampled qubit outcomes after a measure instruction
+        runtime: total solver wall time in seconds
     """
 
     def __init__(self, qt_metrics, n_shots, fock_cutoff, dt):
         super().__init__()
-        self.results = TaskResultAnalog(runtime=0)
         self._qt_metrics = qt_metrics
         self._n_shots = n_shots
         self._fock_cutoff = fock_cutoff
         self._dt = dt
-        self._state_trajectory: list[list] = []
-        self._measurements: np.ndarray | None = None
+
+        self.metric_labels: list[str] = list(qt_metrics.keys())
+        self.times: list[float] = []
+        self.metrics: dict[str, list[float]] = {key: [] for key in self.metric_labels}
+        self.state_trajectory: list[np.ndarray] = []
+        self.measurements: np.ndarray | None = None
+        self.runtime: float = 0.0
 
     def map_QutipExperiment(self, model):
         dims = model.n_qreg * [2] + model.n_qmode * [self._fock_cutoff]
@@ -123,38 +133,21 @@ class QutipExperimentVM(RewriteRule):
         self.n_qmode = model.n_qmode
         self.current_state = qt.tensor([qt.basis(d, 0) for d in dims])
 
-        self.results.times.append(0.0)
-        initial_state = list(self.current_state.full().squeeze())
-        self.results.state = initial_state
-        self._state_trajectory.append(initial_state)
-        self.results.metrics.update(
-            {
-                key: [self._qt_metrics[key](0.0, self.current_state)]
-                for key in self._qt_metrics.keys()
-            }
-        )
+        self.times.append(0.0)
+        self.state_trajectory.append(_qobj_to_state_vector(self.current_state))
+        for key in self.metric_labels:
+            self.metrics[key].append(self._qt_metrics[key](0.0, self.current_state))
 
     def map_QutipMeasurement(self, model):
-        if self._n_shots is None:
-            self.results.counts = {}
-        else:
+        if self._n_shots is not None:
             probs = np.power(np.abs(self.current_state.full()), 2).squeeze()
-            n_shots = self._n_shots
-            inds = np.random.choice(len(probs), size=n_shots, p=probs)
+            inds = np.random.choice(len(probs), size=self._n_shots, p=probs)
             opts = self.n_qreg * [[0, 1]] + self.n_qmode * [
                 list(range(self._fock_cutoff))
             ]
             bases = list(itertools.product(*opts))
             shots = np.array([bases[ind] for ind in inds])
-            self._measurements = shots[:, : self.n_qreg].astype(np.int64)
-            bitstrings = ["".join(map(str, shot)) for shot in shots]
-            self.results.counts = {
-                bitstring: bitstrings.count(bitstring) for bitstring in bitstrings
-            }
-
-        self.results.state = list(
-            self.current_state.full().squeeze(),
-        )
+            self.measurements = shots[:, : self.n_qreg].astype(np.int64)
 
     def map_QutipOperation(self, model):
         duration = model.duration
@@ -174,22 +167,18 @@ class QutipExperimentVM(RewriteRule):
             e_ops=self._qt_metrics,
             options={"store_states": True},
         )
-        self.results.runtime = time.time() - start_runtime + self.results.runtime
+        self.runtime += time.time() - start_runtime
 
-        self.results.times.extend([t + self.results.times[-1] for t in tspan][1:])
+        self.times.extend([t + self.times[-1] for t in tspan][1:])
 
-        for idx, key in enumerate(self.results.metrics.keys()):
-            self.results.metrics[key].extend(result_qobj.expect[idx].tolist()[1:])
+        for idx, key in enumerate(self.metric_labels):
+            self.metrics[key].extend(result_qobj.expect[idx].tolist()[1:])
 
         if result_qobj.states is not None:
             for st in result_qobj.states[1:]:
-                self._state_trajectory.append(list(st.full().squeeze()))
+                self.state_trajectory.append(_qobj_to_state_vector(st))
 
         self.current_state = result_qobj.final_state
-
-        self.results.state = list(
-            result_qobj.final_state.full().squeeze(),
-        )
 
 
 class QutipBackendCompiler(ConversionRule):

--- a/src/oqd_analog_emulator/datastore.py
+++ b/src/oqd_analog_emulator/datastore.py
@@ -1,0 +1,127 @@
+# Copyright 2024-2025 Open Quantum Design
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+from importlib.metadata import version
+from typing import List, Optional, Union
+
+import numpy as np
+
+from oqd_core.backend.task import TaskArgsAnalog, TaskResultAnalog
+from oqd_dataschema import AnalogEmulatorDataGroup, Datastore, Dataset
+
+########################################################################################
+
+__all__ = [
+    "EMULATION_GROUP_KEY",
+    "metric_labels_from_dataset",
+    "task_result_to_datastore",
+]
+
+EMULATION_GROUP_KEY = "emulation"
+
+########################################################################################
+
+
+def _complex_list_to_array(values: List) -> np.ndarray:
+    """Convert a list of ComplexFloat or complex values to a 1D complex128 array."""
+    out = np.empty(len(values), dtype=np.complex128)
+    for i, value in enumerate(values):
+        if hasattr(value, "real") and hasattr(value, "imag"):
+            out[i] = complex(value.real, value.imag)
+        else:
+            out[i] = complex(value)
+    return out
+
+
+def metric_labels_from_dataset(metrics_dataset: Dataset) -> List[str]:
+    """Decode metric axis labels stored in a metrics dataset's attrs."""
+    raw = metrics_dataset.attrs.get("metric_labels", "[]")
+    return json.loads(raw)
+
+
+def task_result_to_datastore(
+    result: TaskResultAnalog,
+    args: TaskArgsAnalog,
+    *,
+    state_trajectory: Optional[List[List]] = None,
+    measurements: Optional[np.ndarray] = None,
+    backend: str = "qutip",
+) -> Datastore:
+    """
+    Build an [`Datastore`][oqd_dataschema.datastore.Datastore] from analog emulator output.
+
+    Args:
+        result: Raw simulation results from the QuTiP virtual machine.
+        args: Task arguments used for the run (metadata source).
+        state_trajectory: State vectors at each time step, if collected.
+        measurements: Sampled qubit outcomes of shape ``(n_shots, n_qubits)``.
+        backend: Backend identifier stored in group attrs.
+    """
+    times = np.asarray(result.times, dtype=np.float64)
+    metric_labels = list(result.metrics.keys())
+
+    metrics_dataset = None
+    if metric_labels:
+        metrics_data = np.column_stack(
+            [np.asarray(result.metrics[label], dtype=np.float64) for label in metric_labels]
+        )
+        metrics_dataset = Dataset(
+            data=metrics_data,
+            attrs={"metric_labels": json.dumps(metric_labels)},
+        )
+
+    state_dataset = None
+    if state_trajectory is not None and len(state_trajectory) > 0:
+        state_rows = [_complex_list_to_array(row) for row in state_trajectory]
+        state_dataset = Dataset(data=np.vstack(state_rows))
+
+    measurements_dataset = None
+    if measurements is not None and measurements.size > 0:
+        measurements_dataset = Dataset(
+            data=np.asarray(measurements, dtype=np.int64),
+            attrs={
+                "axis_0": "shots",
+                "axis_1": "qubits",
+            },
+        )
+
+    try:
+        pkg_version = version("oqd-analog-emulator")
+    except Exception:
+        pkg_version = "unknown"
+
+    group_attrs = {
+        "backend": backend,
+        "version": pkg_version,
+        "dt": args.dt,
+        "fock_cutoff": args.fock_cutoff,
+        "layer": args.layer,
+    }
+    if args.n_shots is not None:
+        group_attrs["n_shots"] = args.n_shots
+    if result.runtime is not None:
+        group_attrs["runtime"] = result.runtime
+
+    emulation = AnalogEmulatorDataGroup(
+        attrs=group_attrs,
+        times=Dataset(data=times),
+        metrics=metrics_dataset,
+        state=state_dataset,
+        measurements=measurements_dataset,
+    )
+
+    return Datastore(groups={EMULATION_GROUP_KEY: emulation})

--- a/src/oqd_analog_emulator/datastore.py
+++ b/src/oqd_analog_emulator/datastore.py
@@ -14,85 +14,61 @@
 
 from __future__ import annotations
 
-import json
 from importlib.metadata import version
-from typing import List, Optional, Union
+from typing import TYPE_CHECKING
 
 import numpy as np
 
-from oqd_core.backend.task import TaskArgsAnalog, TaskResultAnalog
 from oqd_dataschema import AnalogEmulatorDataGroup, Datastore, Dataset
+
+if TYPE_CHECKING:
+    from oqd_analog_emulator.conversion import QutipExperimentVM
+    from oqd_analog_emulator.interface import TaskArgsQutip
 
 ########################################################################################
 
 __all__ = [
     "EMULATION_GROUP_KEY",
-    "metric_labels_from_dataset",
-    "task_result_to_datastore",
+    "METRIC_LABELS_ATTR",
+    "vm_to_datastore",
 ]
 
 EMULATION_GROUP_KEY = "emulation"
+METRIC_LABELS_ATTR = "metric_labels"
 
 ########################################################################################
 
 
-def _complex_list_to_array(values: List) -> np.ndarray:
-    """Convert a list of ComplexFloat or complex values to a 1D complex128 array."""
-    out = np.empty(len(values), dtype=np.complex128)
-    for i, value in enumerate(values):
-        if hasattr(value, "real") and hasattr(value, "imag"):
-            out[i] = complex(value.real, value.imag)
-        else:
-            out[i] = complex(value)
-    return out
-
-
-def metric_labels_from_dataset(metrics_dataset: Dataset) -> List[str]:
-    """Decode metric axis labels stored in a metrics dataset's attrs."""
-    raw = metrics_dataset.attrs.get("metric_labels", "[]")
-    return json.loads(raw)
-
-
-def task_result_to_datastore(
-    result: TaskResultAnalog,
-    args: TaskArgsAnalog,
-    *,
-    state_trajectory: Optional[List[List]] = None,
-    measurements: Optional[np.ndarray] = None,
-    backend: str = "qutip",
-) -> Datastore:
+def vm_to_datastore(vm: QutipExperimentVM, args: TaskArgsQutip) -> Datastore:
     """
-    Build an [`Datastore`][oqd_dataschema.datastore.Datastore] from analog emulator output.
+    Build a [`Datastore`][oqd_dataschema.datastore.Datastore] from VM run data.
 
-    Args:
-        result: Raw simulation results from the QuTiP virtual machine.
-        args: Task arguments used for the run (metadata source).
-        state_trajectory: State vectors at each time step, if collected.
-        measurements: Sampled qubit outcomes of shape ``(n_shots, n_qubits)``.
-        backend: Backend identifier stored in group attrs.
+    Expects ``vm`` to hold plain numpy-friendly collections populated during
+    simulation (no ``TaskResultAnalog`` intermediate).
     """
-    times = np.asarray(result.times, dtype=np.float64)
-    metric_labels = list(result.metrics.keys())
+    times = np.asarray(vm.times, dtype=np.float64)
 
     metrics_dataset = None
-    if metric_labels:
+    if vm.metric_labels:
         metrics_data = np.column_stack(
-            [np.asarray(result.metrics[label], dtype=np.float64) for label in metric_labels]
+            [
+                np.asarray(vm.metrics[label], dtype=np.float64)
+                for label in vm.metric_labels
+            ]
         )
         metrics_dataset = Dataset(
             data=metrics_data,
-            attrs={"metric_labels": json.dumps(metric_labels)},
+            attrs={METRIC_LABELS_ATTR: ",".join(vm.metric_labels)},
         )
 
     state_dataset = None
-    if state_trajectory is not None and len(state_trajectory) > 0:
-        state_rows = [_complex_list_to_array(row) for row in state_trajectory]
-        state_dataset = Dataset(data=np.vstack(state_rows))
+    if vm.state_trajectory:
+        state_dataset = Dataset(data=np.vstack(vm.state_trajectory))
 
     measurements_dataset = None
-    if measurements is not None and measurements.size > 0:
+    if vm.measurements is not None and vm.measurements.size > 0:
         measurements_dataset = Dataset(
-            data=np.asarray(measurements, dtype=np.int64),
+            data=vm.measurements,
             attrs={
                 "axis_0": "shots",
                 "axis_1": "qubits",
@@ -105,16 +81,15 @@ def task_result_to_datastore(
         pkg_version = "unknown"
 
     group_attrs = {
-        "backend": backend,
+        "backend": "qutip",
         "version": pkg_version,
         "dt": args.dt,
         "fock_cutoff": args.fock_cutoff,
         "layer": args.layer,
+        "runtime": vm.runtime,
     }
     if args.n_shots is not None:
         group_attrs["n_shots"] = args.n_shots
-    if result.runtime is not None:
-        group_attrs["runtime"] = result.runtime
 
     emulation = AnalogEmulatorDataGroup(
         attrs=group_attrs,

--- a/src/oqd_analog_emulator/passes.py
+++ b/src/oqd_analog_emulator/passes.py
@@ -17,6 +17,7 @@ from oqd_analog_emulator.conversion import (
     QutipExperimentVM,
     QutipMetricConversion,
 )
+from oqd_analog_emulator.datastore import task_result_to_datastore
 
 from oqd_compiler_infrastructure import Post, Pre
 
@@ -63,27 +64,31 @@ def compiler_analog_args_to_qutipIR(model):
 
 def run_qutip_experiment(model: QutipExperimentVM, args):
     """
-    This takes in a [`QutipExperiment`][oqd_analog_emulator.interface.QutipExperiment] and produces a TaskResultAnalog object
+    Run a [`QutipExperiment`][oqd_analog_emulator.interface.QutipExperiment] and return a dataschema [`Datastore`][oqd_dataschema.datastore.Datastore].
 
     Args:
         model (QutipExperiment):
-        args: (Qutip
+        args: Compiled QuTiP task arguments.
 
     Returns:
-        (TaskResultAnalog): Contains results of the simulation
+        Datastore containing an [`AnalogEmulatorDataGroup`][oqd_dataschema.groups.analog_emulator.AnalogEmulatorDataGroup] under the ``emulation`` key.
 
     """
     n_qreg = model.n_qreg
     n_qmode = model.n_qmode
     metrics = Post(QutipMetricConversion(n_qreg=n_qreg, n_qmode=n_qmode))(args.metrics)
-    interpreter = Pre(
-        QutipExperimentVM(
-            qt_metrics=metrics,
-            n_shots=args.n_shots,
-            fock_cutoff=args.fock_cutoff,
-            dt=args.dt,
-        )
+    vm = QutipExperimentVM(
+        qt_metrics=metrics,
+        n_shots=args.n_shots,
+        fock_cutoff=args.fock_cutoff,
+        dt=args.dt,
     )
+    interpreter = Pre(vm)
     interpreter(model=model)
 
-    return interpreter.children[0].results
+    return task_result_to_datastore(
+        vm.results,
+        args,
+        state_trajectory=vm._state_trajectory,
+        measurements=vm._measurements,
+    )

--- a/src/oqd_analog_emulator/passes.py
+++ b/src/oqd_analog_emulator/passes.py
@@ -17,7 +17,7 @@ from oqd_analog_emulator.conversion import (
     QutipExperimentVM,
     QutipMetricConversion,
 )
-from oqd_analog_emulator.datastore import task_result_to_datastore
+from oqd_analog_emulator.datastore import vm_to_datastore
 
 from oqd_compiler_infrastructure import Post, Pre
 
@@ -86,9 +86,4 @@ def run_qutip_experiment(model: QutipExperimentVM, args):
     interpreter = Pre(vm)
     interpreter(model=model)
 
-    return task_result_to_datastore(
-        vm.results,
-        args,
-        state_trajectory=vm._state_trajectory,
-        measurements=vm._measurements,
-    )
+    return vm_to_datastore(vm, args)

--- a/src/oqd_analog_emulator/qutip_backend.py
+++ b/src/oqd_analog_emulator/qutip_backend.py
@@ -100,7 +100,8 @@ class QutipBackend(BackendBase):
             task (Optional[Task]): Run experiment from a [`Task`][oqd_core.backend.task.Task] object
 
         Returns:
-            TaskResultAnalog object containing the simulation results.
+            [`Datastore`][oqd_dataschema.datastore.Datastore] with simulation results
+            under the ``emulation`` group.
 
         Note:
             only one of task or experiment must be provided.

--- a/tests/test_qutip_backend.py
+++ b/tests/test_qutip_backend.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
-import pathlib
-
 import pytest
 
 import numpy as np
@@ -35,10 +32,7 @@ from oqd_core.interface.analog.operator import (
 from oqd_core.interface.analog.operation import AnalogCircuit, AnalogGate
 from oqd_core.backend.metric import Expectation
 from oqd_core.backend.task import Task, TaskArgsAnalog
-from oqd_analog_emulator.datastore import (
-    EMULATION_GROUP_KEY,
-    metric_labels_from_dataset,
-)
+from oqd_analog_emulator.datastore import EMULATION_GROUP_KEY
 from oqd_analog_emulator.qutip_backend import QutipBackend
 from oqd_dataschema import Datastore
 
@@ -61,7 +55,7 @@ def emulation_group(datastore: Datastore):
 
 def metric_series(datastore: Datastore, label: str) -> np.ndarray:
     sim = emulation_group(datastore)
-    labels = metric_labels_from_dataset(sim.metrics)
+    labels = sim.metrics.attrs["metric_labels"].split(",")
     idx = labels.index(label)
     return sim.metrics.data[:, idx]
 
@@ -499,7 +493,7 @@ def test_datastore_hdf5_roundtrip(one_qubit_rabi_flopping_protocol, tmp_path):
     assert sim.attrs["backend"] == "qutip"
     assert sim.attrs["dt"] == args.dt
     assert sim.attrs["fock_cutoff"] == args.fock_cutoff
-    assert metric_labels_from_dataset(sim.metrics) == ["Z"]
+    assert sim.metrics.attrs["metric_labels"] == "Z"
     assert len(sim.times.data) == len(metric_series(reloaded, "Z"))
     assert abs(metric_series(reloaded, "Z")[-1] - 0) <= 0.001
 

--- a/tests/test_qutip_backend.py
+++ b/tests/test_qutip_backend.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+import pathlib
+
 import pytest
 
 import numpy as np
@@ -32,7 +35,12 @@ from oqd_core.interface.analog.operator import (
 from oqd_core.interface.analog.operation import AnalogCircuit, AnalogGate
 from oqd_core.backend.metric import Expectation
 from oqd_core.backend.task import Task, TaskArgsAnalog
+from oqd_analog_emulator.datastore import (
+    EMULATION_GROUP_KEY,
+    metric_labels_from_dataset,
+)
 from oqd_analog_emulator.qutip_backend import QutipBackend
+from oqd_dataschema import Datastore
 
 ########################################################################################
 
@@ -45,6 +53,22 @@ X, Y, Z, PI, A, C, LI = (
     Creation(),
     Identity(),
 )
+
+
+def emulation_group(datastore: Datastore):
+    return datastore.groups[EMULATION_GROUP_KEY]
+
+
+def metric_series(datastore: Datastore, label: str) -> np.ndarray:
+    sim = emulation_group(datastore)
+    labels = metric_labels_from_dataset(sim.metrics)
+    idx = labels.index(label)
+    return sim.metrics.data[:, idx]
+
+
+def final_state_amplitudes(datastore: Datastore):
+    state = emulation_group(datastore).state.data[-1]
+    return state.real.tolist(), state.imag.tolist()
 
 
 @pytest.fixture
@@ -160,14 +184,6 @@ def three_qubit_GHz_protocol():
     return ac, args
 
 
-def get_amplitude_arrays(state: list):
-    real_amplitudes, imag_amplitudes = [], []
-    for x in state:
-        real_amplitudes.append(x.real)
-        imag_amplitudes.append(x.imag)
-    return real_amplitudes, imag_amplitudes
-
-
 def assert_lists_close(list1, list2, tolerance=0.001):
     assert len(list1) == len(list2), "The input lists have different length"
     for i, (elem1, elem2) in enumerate(zip(list1, list2)):
@@ -185,13 +201,13 @@ def test_one_qubit_rabi_flopping(one_qubit_rabi_flopping_protocol):
 
     backend = QutipBackend()
 
-    results = backend.run(task=task)
+    datastore = backend.run(task=task)
 
-    real_amplitudes, imag_amplitudes = get_amplitude_arrays(results.state)
+    real_amplitudes, imag_amplitudes = final_state_amplitudes(datastore)
 
     assert_lists_close(real_amplitudes, [-0.707, 0])
     assert_lists_close(imag_amplitudes, [0, 0.707])
-    assert abs(results.metrics["Z"][-1] - 0) <= 0.001
+    assert abs(metric_series(datastore, "Z")[-1] - 0) <= 0.001
 
 
 def test_bell_state_standard(bell_state_standard_protocol):
@@ -203,14 +219,14 @@ def test_bell_state_standard(bell_state_standard_protocol):
 
     backend = QutipBackend()
 
-    results = backend.run(task=task)
+    datastore = backend.run(task=task)
 
-    real_amplitudes, imag_amplitudes = get_amplitude_arrays(results.state)
+    real_amplitudes, imag_amplitudes = final_state_amplitudes(datastore)
 
     assert_lists_close(real_amplitudes, [0.707, 0, 0, 0.707])
     assert_lists_close(imag_amplitudes, [0, 0, 0, 0])
-    assert abs(results.metrics["Z^0"][-1] - 0) <= 0.001
-    assert abs(results.metrics["Z^1"][-1] - 0) <= 0.001
+    assert abs(metric_series(datastore, "Z^0")[-1] - 0) <= 0.001
+    assert abs(metric_series(datastore, "Z^1")[-1] - 0) <= 0.001
 
 
 def test_ghz_state(three_qubit_GHz_protocol):
@@ -222,15 +238,15 @@ def test_ghz_state(three_qubit_GHz_protocol):
 
     backend = QutipBackend()
 
-    results = backend.run(task=task)
+    datastore = backend.run(task=task)
 
-    real_amplitudes, imag_amplitudes = get_amplitude_arrays(results.state)
+    real_amplitudes, imag_amplitudes = final_state_amplitudes(datastore)
 
     assert_lists_close(real_amplitudes, [0.707, 0, 0, 0, 0, 0, 0, 0.707])
     assert_lists_close(imag_amplitudes, [0, 0, 0, 0, 0, 0, 0, 0])
-    assert abs(results.metrics["Z^0"][-1] - 0) <= 0.001
-    assert abs(results.metrics["Z^1"][-1] - 0) <= 0.001
-    assert abs(results.metrics["Z^2"][-1] - 0) <= 0.001
+    assert abs(metric_series(datastore, "Z^0")[-1] - 0) <= 0.001
+    assert abs(metric_series(datastore, "Z^1")[-1] - 0) <= 0.001
+    assert abs(metric_series(datastore, "Z^2")[-1] - 0) <= 0.001
 
 
 def test_identity_operation_simple():
@@ -254,13 +270,13 @@ def test_identity_operation_simple():
 
     backend = QutipBackend()
 
-    results = backend.run(task=task)
+    datastore = backend.run(task=task)
 
-    real_amplitudes, imag_amplitudes = get_amplitude_arrays(results.state)
+    real_amplitudes, imag_amplitudes = final_state_amplitudes(datastore)
 
     assert_lists_close(real_amplitudes, [1, 0])
     assert_lists_close(imag_amplitudes, [0, 0])
-    assert abs(results.metrics["Z"][-1] - 1) <= 0.001
+    assert abs(metric_series(datastore, "Z")[-1] - 1) <= 0.001
 
 
 def test_identity_operation_nested():
@@ -288,13 +304,13 @@ def test_identity_operation_nested():
 
     backend = QutipBackend()
 
-    results = backend.run(task=task)
+    datastore = backend.run(task=task)
 
-    real_amplitudes, imag_amplitudes = get_amplitude_arrays(results.state)
+    real_amplitudes, imag_amplitudes = final_state_amplitudes(datastore)
 
     assert_lists_close(real_amplitudes, [1, 0])
     assert_lists_close(imag_amplitudes, [0, 0])
-    assert abs(results.metrics["Z"][-1] - 1) <= 0.001
+    assert abs(metric_series(datastore, "Z")[-1] - 1) <= 0.001
 
 
 def test_identity_operation_three_qubit_simple():
@@ -321,15 +337,15 @@ def test_identity_operation_three_qubit_simple():
 
     backend = QutipBackend()
 
-    results = backend.run(task=task)
+    datastore = backend.run(task=task)
 
-    real_amplitudes, imag_amplitudes = get_amplitude_arrays(results.state)
+    real_amplitudes, imag_amplitudes = final_state_amplitudes(datastore)
 
     assert_lists_close(real_amplitudes, [1, 0, 0, 0, 0, 0, 0, 0])
     assert_lists_close(imag_amplitudes, [0, 0, 0, 0, 0, 0, 0, 0])
-    assert abs(results.metrics["Z^0"][-1] - 1) <= 0.001
-    assert abs(results.metrics["Z^1"][-1] - 1) <= 0.001
-    assert abs(results.metrics["Z^2"][-1] - 1) <= 0.001
+    assert abs(metric_series(datastore, "Z^0")[-1] - 1) <= 0.001
+    assert abs(metric_series(datastore, "Z^1")[-1] - 1) <= 0.001
+    assert abs(metric_series(datastore, "Z^2")[-1] - 1) <= 0.001
 
 
 def test_identity_operation_three_qubit_nested():
@@ -367,15 +383,15 @@ def test_identity_operation_three_qubit_nested():
 
     backend = QutipBackend()
 
-    results = backend.run(task=task)
+    datastore = backend.run(task=task)
 
-    real_amplitudes, imag_amplitudes = get_amplitude_arrays(results.state)
+    real_amplitudes, imag_amplitudes = final_state_amplitudes(datastore)
 
     assert_lists_close(real_amplitudes, [1, 0, 0, 0, 0, 0, 0, 0])
     assert_lists_close(imag_amplitudes, [0, 0, 0, 0, 0, 0, 0, 0])
-    assert abs(results.metrics["Z^0"][-1] - 1) <= 0.001
-    assert abs(results.metrics["Z^1"][-1] - 1) <= 0.001
-    assert abs(results.metrics["Z^2"][-1] - 1) <= 0.001
+    assert abs(metric_series(datastore, "Z^0")[-1] - 1) <= 0.001
+    assert abs(metric_series(datastore, "Z^1")[-1] - 1) <= 0.001
+    assert abs(metric_series(datastore, "Z^2")[-1] - 1) <= 0.001
 
 
 def test_metrics_count_none(one_qubit_rabi_flopping_protocol):
@@ -395,10 +411,11 @@ def test_metrics_count_none(one_qubit_rabi_flopping_protocol):
 
     backend = QutipBackend()
 
-    results = backend.run(task=task)
+    datastore = backend.run(task=task)
+    sim = emulation_group(datastore)
 
-    assert results.counts == {}
-    assert results.metrics == {}
+    assert sim.metrics is None
+    assert sim.measurements is None
 
 
 def test_one_qubit_rabi_flopping_canonicalization(one_qubit_rabi_flopping_protocol):
@@ -417,13 +434,13 @@ def test_one_qubit_rabi_flopping_canonicalization(one_qubit_rabi_flopping_protoc
 
     backend = QutipBackend()
 
-    results = backend.run(task=task)
+    datastore = backend.run(task=task)
 
-    real_amplitudes, imag_amplitudes = get_amplitude_arrays(results.state)
+    real_amplitudes, imag_amplitudes = final_state_amplitudes(datastore)
 
     assert np.allclose(real_amplitudes, [-0.707, 0], atol=0.001)
     assert np.allclose(imag_amplitudes, [0, 0.707], atol=0.001)
-    assert pytest.approx(results.metrics["Z"][-1], abs=0.001) == 0
+    assert pytest.approx(metric_series(datastore, "Z")[-1], abs=0.001) == 0
 
 
 def test_bell_state_canonicalization(bell_state_standard_protocol):
@@ -458,11 +475,51 @@ def test_bell_state_canonicalization(bell_state_standard_protocol):
 
     backend = QutipBackend()
 
-    results = backend.run(task=task)
+    datastore = backend.run(task=task)
 
-    real_amplitudes, imag_amplitudes = get_amplitude_arrays(results.state)
+    real_amplitudes, imag_amplitudes = final_state_amplitudes(datastore)
 
     assert np.allclose(real_amplitudes, [0.707, 0, 0, 0.707], atol=0.001)
     assert np.allclose(imag_amplitudes, [0, 0, 0, 0], atol=0.001)
-    assert pytest.approx(results.metrics["Z^0"][-1], abs=0.001) == 0
-    assert pytest.approx(results.metrics["Z^1"][-1], abs=0.001) == 0
+    assert pytest.approx(metric_series(datastore, "Z^0")[-1], abs=0.001) == 0
+    assert pytest.approx(metric_series(datastore, "Z^1")[-1], abs=0.001) == 0
+
+
+def test_datastore_hdf5_roundtrip(one_qubit_rabi_flopping_protocol, tmp_path):
+    """Metadata and metric labels survive an HDF5 round-trip."""
+    ac, args = one_qubit_rabi_flopping_protocol
+    task = Task(program=ac, args=args)
+    datastore = QutipBackend().run(task=task)
+
+    filepath = tmp_path / "rabi_run.h5"
+    datastore.model_dump_hdf5(filepath)
+    reloaded = Datastore.model_validate_hdf5(filepath)
+
+    sim = emulation_group(reloaded)
+    assert sim.attrs["backend"] == "qutip"
+    assert sim.attrs["dt"] == args.dt
+    assert sim.attrs["fock_cutoff"] == args.fock_cutoff
+    assert metric_labels_from_dataset(sim.metrics) == ["Z"]
+    assert len(sim.times.data) == len(metric_series(reloaded, "Z"))
+    assert abs(metric_series(reloaded, "Z")[-1] - 0) <= 0.001
+
+
+def test_measurements_dataset(tmp_path):
+    """Measurements are stored when a circuit includes a measure instruction."""
+    ac = AnalogCircuit()
+    ac.evolve(duration=np.pi / 2, gate=AnalogGate(hamiltonian=X))
+    ac.measure()
+    args = TaskArgsAnalog(
+        n_shots=50,
+        fock_cutoff=4,
+        metrics={"Z": Expectation(operator=Z)},
+        dt=1e-2,
+    )
+    task = Task(program=ac, args=args)
+    datastore = QutipBackend().run(task=task)
+    sim = emulation_group(datastore)
+
+    assert sim.measurements is not None
+    assert sim.measurements.data.shape == (50, 1)
+    assert sim.measurements.attrs["axis_0"] == "shots"
+    assert sim.measurements.attrs["axis_1"] == "qubits"


### PR DESCRIPTION
## Summary

Closes [#9](https://github.com/OpenQuantumDesign/oqd-analog-emulator/issues/9).

`QutipBackend.run(task)` now returns an `oqd_dataschema.Datastore` with an `emulation` group (`AnalogEmulatorDataGroup`) instead of `TaskResultAnalog`.

- Metrics stacked as `(n_tsteps, n_metrics)`; names in `metrics.attrs["metric_labels"]` (JSON)
- Full state trajectory in `state`; shot outcomes in `measurements` when the circuit includes `measure()`
- README Rabi example updated (`model_dump_hdf5`, read metrics from datastore)

## Depends on

**Requires `AnalogEmulatorDataGroup` on `oqd-dataschema` `main`** - merge [oqd-dataschema #11](https://github.com/OpenQuantumDesign/oqd-dataschema/pull/11) first (CI will fail until that lands).

## Test plan

- [x] All **10** existing backend tests pass (Rabi, Bell, GHZ, identity, canonicalization, empty metrics)
- [x] **2** new tests: HDF5 round-trip (attrs + metric labels), measurements dataset with `measure()`
- [x] Manual checks: axis alignment (`times` / `metrics` / `state`), no measurements without `measure()`, compile path still works
- [x] `oqd-dataschema` suite with new group: **147 passed**, 57 xfailed (pre-existing)

**Note:** Until dataschema is merged, install with `pip install git+https://github.com/OpenQuantumDesign/oqd-dataschema@feat/analog-emulator-data-group` for local/CI review.